### PR TITLE
Remove -Werror from KBUILD_CFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -360,7 +360,7 @@ KBUILD_CPPFLAGS := -D__KERNEL__ -D__UBOOT__
 KBUILD_CFLAGS   := -Wall -Wstrict-prototypes \
 		   -Wno-format-security \
 		   -fno-builtin -ffreestanding
-KBUILD_CFLAGS	+= -fshort-wchar -Werror
+KBUILD_CFLAGS	+= -fshort-wchar
 KBUILD_AFLAGS   := -D__ASSEMBLY__
 
 # Read UBOOTRELEASE from include/config/uboot.release (if it exists)


### PR DESCRIPTION
This is an extremely annoying thing to put into a build script as new compilers add new warnings, breaking builds for no reason.

Keep it to testing focused CIs.