### PR TITLE
make.sh: Don't check for python2

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -706,11 +706,6 @@ function pack_fit_image()
 	if ! which dtc >/dev/null 2>&1 ; then
 		echo "ERROR: No 'dtc', please: apt-get install device-tree-compiler"
 		exit 1
-	elif [ "${ARM64_TRUSTZONE}" == "y" ]; then
-		if ! which python2 >/dev/null 2>&1 ; then
-			echo "ERROR: No python2"
-			exit 1
-		fi
 	fi
 
 	# If we don't plan to have uboot in uboot.img in case of: SPL => Trust => Kernel, creating empty files.


### PR DESCRIPTION
Python 2 isn't required for the boards we care about, and even if it is required, it should fail when it calls python2, not at an arbitrary point in make.sh.